### PR TITLE
Summary generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,13 @@ pub struct TapestryFragment {
 /// abstracting the logic from the services calling them.
 #[async_trait]
 pub trait Loom<T: Config> {
+	/// Represents an object to use for constructing [`Loom::RequestMessages`] from.
 	type Message;
+	/// Represents the request message type used to prompt a certain LLM.
+	///
+	/// This varies between LLMs and their libraries.
 	type RequestMessages;
+	/// Represents the response type returned by the LLM library.
 	type Response;
 
 	/// Prompt Loreweaver for a response for [`WeavingID`].
@@ -364,15 +369,15 @@ impl<T: Config> Loom<T> for Loreweaver<T> {
 				let words_summary = tokens_left as f32 * TOKEN_WORD_RATIO;
 
 				messages.push(
-				ChatCompletionRequestMessageArgs::default()
-					.content(format!("Generate a summary of the entire adventure so far. Respond with {} words or less", words_summary))
-					.role(Role::System)
-					.build()
-					.map_err(|e| {
-						error!("Failed to build ChatCompletionRequestMessageArgs: {}", e);
-						e
-					})?
-			);
+					ChatCompletionRequestMessageArgs::default()
+						.content(format!("Generate a summary of the entire adventure so far. Respond with {} words or less", words_summary))
+						.role(Role::System)
+						.build()
+						.map_err(|e| {
+							error!("Failed to build ChatCompletionRequestMessageArgs: {}", e);
+							e
+						})?
+				);
 
 				let res = <Loreweaver<T> as Loom<T>>::prompt(&mut messages, tokens_left)
 					.await

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -44,7 +44,7 @@ pub trait TapestryChestHandler {
 	async fn save_tapestry_fragment<TID: TapestryId>(
 		tapestry_id: TID,
 		tapestry_fragment: TapestryFragment,
-		_increment: bool,
+		increment: bool,
 	) -> crate::Result<()>;
 	/// Save tapestry metadata.
 	///
@@ -162,12 +162,6 @@ impl TapestryChestHandler for TapestryChest {
 		let instance = match get_score_from_last_zset_member(&mut con, base_key).await? {
 			Some(instance) => instance,
 			None => {
-				// TODO
-				// con.zincr(&base_key, 0, 1).await.map_err(|e| {
-				// 	error!("Failed to save story part to Redis: {}", e);
-				// 	WeaveError::Storage
-				// })?;
-
 				con.zadd(base_key, 0, 0).await.map_err(|e| {
 					error!("Failed to save story part to Redis: {}", e);
 					StorageError::Redis(e)


### PR DESCRIPTION
Generate a summary of the `TapestryFragment` once we reach a certain token threshold. 

Create a new instance of the `TapestryFragment` (i.e. increment the redis zset score) so that we start tracking a new message history with the summary as the starting message.